### PR TITLE
Gnome Collisions

### DIFF
--- a/Assets/Prefabs/Gnome.prefab
+++ b/Assets/Prefabs/Gnome.prefab
@@ -81,6 +81,7 @@ MonoBehaviour:
   explosionParticles: {fileID: 6358743609323874255}
   onomatopeiasFolder: {fileID: 789535763280683588}
   shatterObject: {fileID: 5499217459750255952, guid: 265132fcf75925d468aed94b9848f13c, type: 3}
+  speedToBreak: 12
 --- !u!54 &8661964909254828076
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/GnomeTestScene.unity
+++ b/Assets/Scenes/GnomeTestScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028331, g: 0.2257133, b: 0.3069217, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -227,7 +227,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &436505401
 GameObject:
@@ -249,7 +249,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &436505402
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -264,7 +264,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   hand: {fileID: 0}
   joint: {fileID: 0}
-  velocityToKill: 0.5
+  velocityToKill: 5
   pointToTrack: {fileID: 436505406}
 --- !u!135 &436505403
 SphereCollider:
@@ -472,7 +472,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
 --- !u!114 &908306831
 MonoBehaviour:
@@ -497,79 +497,6 @@ MonoBehaviour:
   m_LightCookieSize: {x: 1, y: 1}
   m_LightCookieOffset: {x: 0, y: 0}
   m_SoftShadowQuality: 0
---- !u!1001 &1313186911
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2334565146022406582, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 2334565146022406582, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2334565146022406582, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2334565146022406582, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -4.85
-      objectReference: {fileID: 0}
-    - target: {fileID: 2334565146022406582, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2334565146022406582, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2334565146022406582, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2334565146022406582, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2334565146022406582, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2334565146022406582, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2334565146022406582, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3640079733116926812, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
-      propertyPath: m_Name
-      value: PlayerPrefab
-      objectReference: {fileID: 0}
-    - target: {fileID: 3640079733116926812, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6938867320963381821, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
-      propertyPath: velocityToKill
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7381844438155241711, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
-      propertyPath: velocityToKill
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 550c53c313b1ad141a712f11960b7489, type: 3}
 --- !u!1 &1202061222
 GameObject:
   m_ObjectHideFlags: 0
@@ -674,7 +601,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1202061227
 MonoBehaviour:
@@ -694,6 +621,91 @@ MonoBehaviour:
   MinimumPointValue: 0
   points: 10
   ScoreText: {fileID: 0}
+--- !u!1001 &1313186911
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2334565146022406582, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2334565146022406582, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2334565146022406582, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2334565146022406582, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4.85
+      objectReference: {fileID: 0}
+    - target: {fileID: 2334565146022406582, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2334565146022406582, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2334565146022406582, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2334565146022406582, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2334565146022406582, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2334565146022406582, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2334565146022406582, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3640079733116926812, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
+      propertyPath: m_Name
+      value: PlayerPrefab
+      objectReference: {fileID: 0}
+    - target: {fileID: 3640079733116926812, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6938867320963381821, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
+      propertyPath: velocityToKill
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7381844438155241711, guid: 04456a75df9167348a7b3935758a6ccc, type: 3}
+      propertyPath: velocityToKill
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2742003890636414217, guid: 550c53c313b1ad141a712f11960b7489, type: 3}
+      propertyPath: speedToBreak
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 2742003890636414217, guid: 550c53c313b1ad141a712f11960b7489, type: 3}
+      propertyPath: velocityToBreak
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8268631164133716473, guid: 550c53c313b1ad141a712f11960b7489, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 550c53c313b1ad141a712f11960b7489, type: 3}
 --- !u!1 &1665220504
 GameObject:
   m_ObjectHideFlags: 0
@@ -785,7 +797,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1665220508
 MonoBehaviour:
@@ -861,7 +873,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2081888051
 MonoBehaviour:

--- a/Assets/Scripts/Gnomes/GnomeBehavior.cs
+++ b/Assets/Scripts/Gnomes/GnomeBehavior.cs
@@ -50,9 +50,12 @@ public class GnomeBehavior : MonoBehaviour
 
     private int numOfOnomatopeias;
 
+    private float speedBeforePhysicsUpdate;
+
     private Animator animator;
     private EventInstance attachSFX;
     [SerializeField] private GameObject shatterObject;
+    [SerializeField] private float speedToBreak;
     #endregion
 
     private void Awake()
@@ -80,8 +83,19 @@ public class GnomeBehavior : MonoBehaviour
         attachSFX.set3DAttributes(RuntimeUtils.To3DAttributes(GetComponent<Transform>(), rb));
     }
 
+    private void FixedUpdate()
+    {
+        speedBeforePhysicsUpdate = rb.velocity.magnitude;
+    }
+
     private void OnCollisionEnter(Collision collision)
     {
+        Debug.Log(speedBeforePhysicsUpdate);        
+        if(speedBeforePhysicsUpdate > speedToBreak)
+        {
+            Die();
+        }
+
         // If gnome should be attacking the player, and has made contact with the player
         // Grapple the player and start dealing damage
         if (isAttacking && collision.gameObject.GetComponent<LawnmowerPointsSystem>() != null)

--- a/Assets/Scripts/Gnomes/GnomeBehavior.cs
+++ b/Assets/Scripts/Gnomes/GnomeBehavior.cs
@@ -90,7 +90,7 @@ public class GnomeBehavior : MonoBehaviour
 
     private void OnCollisionEnter(Collision collision)
     {
-        Debug.Log(speedBeforePhysicsUpdate);        
+        //Debug.Log(speedBeforePhysicsUpdate);        
         if(speedBeforePhysicsUpdate > speedToBreak)
         {
             Die();
@@ -124,7 +124,7 @@ public class GnomeBehavior : MonoBehaviour
     /// </summary>
     public void Die()
     {
-        Debug.Log("Die is called");
+        Debug.Log(gameObject.name + " was killed");
         if (!isDead)
         {
             AudioManager.instance.PlayOneShot(FMODEvents.instance.Shatter, transform.position);

--- a/Assets/Scripts/Shovel.cs
+++ b/Assets/Scripts/Shovel.cs
@@ -20,8 +20,7 @@ public class Shovel : MonoBehaviour
         StartCoroutine(AttachToHand());
     }
 
-    // Update is called once per frame
-    void Update()
+    private void FixedUpdate()
     {
         velocityMagnitude = (pointToTrack.position - previousPos).magnitude / Time.deltaTime;
         previousPos = pointToTrack.position;


### PR DESCRIPTION
Gnomes now break when they collide with something at a specified speed.

Moved the shovel's calculation of velocity to FixedUpdate to reorder when the velocity is found and when a collision occurs